### PR TITLE
Small README.md Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Build and export React Components as Web Components without any extra effort.**
 
-Size = ~3kb after gzip
+Size = [~1.5kB after gzip](https://bundlephobia.com/package/react-webcomponentify)
 
 _\* works nicely with preact aswell: See demo_
 


### PR DESCRIPTION
Seems like with TypeScript build introduction, final bundle size dropped about twice https://bundlephobia.com/package/react-webcomponentify